### PR TITLE
一键部署失败以及部署成功后gemini不回复的修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+

--- a/netlify/functions/proxy.ts
+++ b/netlify/functions/proxy.ts
@@ -69,6 +69,7 @@ export default async (request: Request, context: Context) => {
     body: request.body,
     method: request.method,
     headers,
+    duplex: "half"
   });
 
   const responseHeaders = {


### PR DESCRIPTION
问题1：一键部署时失败，提示："Deploy did not succeed: Build cancelled, found file owned by root"​​ 
原因：Netlify 会自动运行 npm install 或 yarn install，所以 ​​node_modules 不应提交到 GitHub​​
解决：删除.gitignore内的node_modules后部署成功。

问题2：部署成功后，gemini不回复，netlify报错："TypeError: RequestInit: duplex option is required when sending a body."
原因：当Netlify Function 使用 fetch() 发送带有请求体（如 POST、PUT）的请求时，​​必须显式设置 duplex: "half"
解决：在proxy.ts文件做以下修改，
` const response = await fetch(url, {
    body: request.body,
    method: request.method,
    headers,
    duplex: "half" // 必须添加此行
  });`